### PR TITLE
Add filtering by school and search by name/grade for students.

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -43,7 +43,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'rest_framework',
     'core',
-    'rest_framework_simplejwt'
+    'rest_framework_simplejwt',
+    'django_filters',
 ]
 
 REST_FRAMEWORK = {

--- a/config/settings.py
+++ b/config/settings.py
@@ -52,6 +52,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_simplejwt.authentication.JWTAuthentication',
+        'rest_framework.authentication.SessionAuthentication'
     ),
 }
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     path('api/', include(router.urls)),
     path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),  
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'), 
+    path('api-auth/', include('rest_framework.urls')),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -1,16 +1,19 @@
 from rest_framework import viewsets
 from .models import School, Teacher, Student
 from .serializers import SchoolSerializer, TeacherSerializer, StudentSerializer
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.filters import SearchFilter
+
 
 class SchoolViewSet(viewsets.ModelViewSet):
     queryset = School.objects.all()
     serializer_class = SchoolSerializer
-    
 class TeacherViewSet(viewsets.ModelViewSet):
     queryset = Teacher.objects.all()
     serializer_class = TeacherSerializer
-    
 class StudentViewSet(viewsets.ModelViewSet):
     queryset = Student.objects.all()
     serializer_class = StudentSerializer
-
+    filter_backends = [DjangoFilterBackend, SearchFilter]
+    filterset_fields = ['school']
+    search_fields = ['name', 'grade']


### PR DESCRIPTION
This PR adds the following features to the Student API:

- Filter students by `school` using DjangoFilterBackend
- Search students by `name` and `grade` using SearchFilter
- Works on both the API and DRF browsable interface

Changes:
- Updated StudentViewSet in core/views.py
- Added DjangoFilterBackend and SearchFilter to filter_backends
- Added filterset_fields = ['school'] and search_fields = ['name', 'grade']
